### PR TITLE
Fixed for HN layout changes in Jan/2015

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
   "name": "Hacker News: Mark All Read",
-  "version": "1.4",
+  "version": "1.41",
   "manifest_version": 2,
   "description": "Save time on HN by marking read the titles and comments you already scanned. And more.",
   "content_scripts": [

--- a/manifest.json
+++ b/manifest.json
@@ -10,12 +10,11 @@
       "js": ["jquery.min.js", "script.js"]
     }
   ],
+  "icons": {
+    "128": "images/HNMarkAllRead.png"
+  },
   "web_accessible_resources": [
     "images/HNMarkAllRead-18.png",
     "styles.css"
   ]
-//  ,
-//  "icons": {
-//    "128": "images/HNMarkAllRead.png"
-//  }
 }

--- a/script.js
+++ b/script.js
@@ -44,7 +44,7 @@ if (!window.location.href.match(/\/item\?/)) { // ignore if displaying a news it
 
     // check which pieces of news have already been marked read and change their color
     $(".subtext").each(function(i,sub) {
-        var mainlink = $(sub.parentNode.previousSibling.childNodes[2].childNodes[0]);
+        var mainlink = $(sub.parentNode.previousSibling.childNodes[2].childNodes[1]); // fixed after HN change jan/2015
 
         titles++;
 
@@ -97,8 +97,9 @@ if (!window.location.href.match(/\/item\?/)) { // ignore if displaying a news it
         if (more_td) more_td.append("&nbsp; <span class='mark_all_read near_more' title='Mark all read'><img src='"+chrome.extension.getURL("/images/HNMarkAllRead-18.png")+"'></img></span>");
 
         $(".mark_all_read").click(function(){
-            $(".title").each(function(i,el) {
-                var mainlink = $($(el).children("a")[0]);
+            $(".subtext").each(function(i,sub) {
+            var mainlink = $(sub.parentNode.previousSibling.childNodes[2].childNodes[1]); // fixed after HN change jan/2015
+
 
                 // add the link to the "read" ones
                 if (!marked_read_urls[mainlink.attr("href")]) {
@@ -387,5 +388,3 @@ if (!window.location.href.match(/\/item\?/)) { // ignore if displaying a news it
         }
     }
 }
-
-


### PR DESCRIPTION
Fixed for the HN changes in Jan/2015. Tested with Chrome 40.0.2214.94 and 41.0.2272.35 beta on Windows, and 40.0.2214.10 beta on Linux.

Also added the icon in the manifest file, so it can be published to the Chrome Web Store.